### PR TITLE
Fix typo in tracking helpers

### DIFF
--- a/ckanext/tracking/helpers.py
+++ b/ckanext/tracking/helpers.py
@@ -15,7 +15,7 @@ def popular(type_: str,
             '{number} recent view', '{number} recent views', number
             )
     elif not title:
-        raise Exception('popular() did not recieve a valid type_ or title')
+        raise Exception('popular() did not receive a valid type_ or title')
     data_dict = {'title': title, 'number': number, 'min': min}
 
     return toolkit.render_snippet('snippets/popular.html', data_dict)


### PR DESCRIPTION
## Summary
- fix misspelling in popular helper exception message

## Testing
- `flake8 ckanext/tracking/helpers.py`

------
https://chatgpt.com/codex/tasks/task_e_684186c82690833295eb4936c7eb3cf2